### PR TITLE
Clean up `resp_tidy()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Imports:
     curl,
     fs,
     glue,
-    httr2 (>= 1.0.0),
+    httr2 (>= 1.1.0),
     jsonlite,
     lifecycle,
     purrr,

--- a/R/resp_tidy.R
+++ b/R/resp_tidy.R
@@ -40,9 +40,7 @@ resp_tidy <- function(resps) {
 
 #' @export
 resp_tidy.httr2_response <- function(resps) {
-  # TODO: Replace this with httr2::resp_request() after
-  # https://github.com/r-lib/httr2/pull/615
-  req <- resps$request
+  req <- httr2::resp_request(resps)
   if (length(req$policies$resp_tidy)) {
     return(
       rlang::exec(
@@ -66,13 +64,7 @@ resp_tidy.list <- function(resps) {
     class(resps) <- c("nectar_responses", "list")
     return(resp_tidy(resps))
   }
-  .nectar_abort(
-    c(
-      "No method is available to {.fn nectar::resp_tidy} this object.",
-      i = "You might want to try {.fn nectar::resp_parse} instead."
-    ),
-    "unsupported_response_class"
-  )
+  NextMethod()
 }
 
 #' @export

--- a/tests/testthat/_snaps/resp_tidy.md
+++ b/tests/testthat/_snaps/resp_tidy.md
@@ -18,5 +18,5 @@
       <error/nectar-error-unsupported_response_class>
       Error in `resp_tidy()`:
       ! No method is available to `nectar::resp_tidy()` this object.
-      i You might want to try `nectar::resp_parse()` instead.
+      i `nectar::resp_tidy()` expects <httr2_response> objects, or lists thereof.
 


### PR DESCRIPTION
Prepare to refactor/maybe redesign `resp_parse()` + `resp_tidy()`.

- Use `httr2::resp_request()`
- Clean up fall-through.